### PR TITLE
Standardize reveal animations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,6 @@
         "gsap": "^3.13.0",
         "phosphor-react": "^1.4.1",
         "react": "^18.2.0",
-        "react-awesome-reveal": "^4.2.5",
         "react-dom": "^18.2.0",
         "react-helmet-async": "^2.0.5",
         "styled-components": "^6.0.2"
@@ -5774,34 +5773,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/react-awesome-reveal": {
-      "version": "4.2.5",
-      "resolved": "https://registry.npmjs.org/react-awesome-reveal/-/react-awesome-reveal-4.2.5.tgz",
-      "integrity": "sha512-oHYoYvgNgfMVQ13UfgO650AkDS58aFGXhoIZDsHMAVjyHfmpG46T1ZXL8t07gO+yPnQ9dQREo7v2p40shxS3GA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/morellodev"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/react-awesome-reveal"
-        }
-      ],
-      "dependencies": {
-        "react-intersection-observer": "^9.4.3",
-        "react-is": "^18.2.0"
-      },
-      "peerDependencies": {
-        "@emotion/react": "^11.0.0",
-        "react": ">=16.14.0"
-      }
-    },
-    "node_modules/react-awesome-reveal/node_modules/react-is": {
-      "version": "18.2.0",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
-      "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w=="
-    },
     "node_modules/react-dom": {
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
@@ -5830,14 +5801,6 @@
       },
       "peerDependencies": {
         "react": "^16.6.0 || ^17.0.0 || ^18.0.0"
-      }
-    },
-    "node_modules/react-intersection-observer": {
-      "version": "9.5.2",
-      "resolved": "https://registry.npmjs.org/react-intersection-observer/-/react-intersection-observer-9.5.2.tgz",
-      "integrity": "sha512-EmoV66/yvksJcGa1rdW0nDNc4I1RifDWkT50gXSFnPLYQ4xUptuDD4V7k+Rj1OgVAlww628KLGcxPXFlOkkU/Q==",
-      "peerDependencies": {
-        "react": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/react-is": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
     "gsap": "^3.13.0",
     "phosphor-react": "^1.4.1",
     "react": "^18.2.0",
-    "react-awesome-reveal": "^4.2.5",
     "react-dom": "^18.2.0",
     "react-helmet-async": "^2.0.5",
     "styled-components": "^6.0.2"

--- a/src/components/About/index.tsx
+++ b/src/components/About/index.tsx
@@ -2,7 +2,7 @@ import { AboutContainer, BodyAbout } from './styles'
 import { Brain, ChatsCircle, Palette, UsersThree } from 'phosphor-react'
 
 import { AboutCard } from '../AboutCard'
-import { Fade } from 'react-awesome-reveal'
+import { Reveal } from '../Reveal'
 import { TitleSection } from '../TitleSection'
 import profileImg from '../../assets/profile.jpg'
 
@@ -10,7 +10,7 @@ export function About() {
   const titleAboutArray = ['S', 'o', 'b', 'r', 'e', ' ', 'm', 'i', 'm']
 
   return (
-    <Fade duration={1000} delay={300} triggerOnce>
+    <Reveal>
       <AboutContainer id="about" className="about-section">
         <div className="profileImg">
           <img loading="lazy" src={profileImg} alt="Imagem de Oliver" />
@@ -63,6 +63,6 @@ export function About() {
           </div>
         </BodyAbout>
       </AboutContainer>
-    </Fade>
+    </Reveal>
   )
 }

--- a/src/components/Blog/index.tsx
+++ b/src/components/Blog/index.tsx
@@ -1,7 +1,7 @@
 import { BlogContainer, BlogCard, BlogGrid } from './styles'
 import { TitleSection } from '../TitleSection'
 import { motion } from 'framer-motion'
-import { Fade } from 'react-awesome-reveal'
+import { Reveal } from '../Reveal'
 import { useEffect, useState } from 'react'
 
 type BlogPost = {
@@ -41,7 +41,7 @@ export function Blog() {
   }, [])
 
   return (
-    <Fade duration={1000} delay={300} triggerOnce>
+    <Reveal>
       <BlogContainer id="blog">
         <TitleSection subtitle="Insights" titleLetterArray={titleBlogArray} />
 
@@ -87,6 +87,6 @@ export function Blog() {
           ))}
         </BlogGrid>
       </BlogContainer>
-    </Fade>
+    </Reveal>
   )
 }

--- a/src/components/Contact/index.tsx
+++ b/src/components/Contact/index.tsx
@@ -6,7 +6,7 @@ import {
   FormProgress,
   InputWrapper,
 } from './styles'
-import { Fade } from 'react-awesome-reveal'
+import { Reveal } from '../Reveal'
 import { TitleSection } from '../TitleSection'
 import { useState, useEffect, useCallback, FormEvent } from 'react'
 import { motion } from 'framer-motion'
@@ -130,7 +130,7 @@ export function Contact() {
   }
 
   return (
-    <Fade duration={1000} delay={300} triggerOnce>
+    <Reveal>
       <ContactContainer id="contact">
         <TitleSection
           subtitle="Contatos"
@@ -213,6 +213,6 @@ export function Contact() {
           </motion.form>
         </BodyContact>
       </ContactContainer>
-    </Fade>
+    </Reveal>
   )
 }

--- a/src/components/Projects/index.tsx
+++ b/src/components/Projects/index.tsx
@@ -7,7 +7,7 @@ import {
   ProjectsHeader,
 } from './styles'
 
-import { Fade } from 'react-awesome-reveal'
+import { Reveal } from '../Reveal'
 import { ProjectCard } from '../ProjectCard'
 import { TitleSection } from '../TitleSection'
 import { useState } from 'react'
@@ -71,7 +71,7 @@ export function Projects() {
   }
 
   return (
-    <Fade duration={1000} delay={300} triggerOnce>
+    <Reveal>
       <ProjectsContainer id="projects">
         <TitleSection
           subtitle="Criações"
@@ -184,6 +184,6 @@ export function Projects() {
           </div>
         </BodyProjects>
       </ProjectsContainer>
-    </Fade>
+    </Reveal>
   )
 }

--- a/src/components/Reveal/index.tsx
+++ b/src/components/Reveal/index.tsx
@@ -1,0 +1,37 @@
+import { motion, useAnimation, useInView } from 'framer-motion'
+import { ReactNode, useEffect, useRef } from 'react'
+
+interface RevealProps {
+  children: ReactNode
+  width?: string
+}
+
+export function Reveal({ children, width = '100%' }: RevealProps) {
+  const ref = useRef(null)
+  const isInView = useInView(ref, { once: true })
+  const mainControls = useAnimation()
+
+  useEffect(() => {
+    if (isInView) {
+      mainControls.start('visible')
+    }
+  }, [isInView, mainControls])
+
+  return (
+    <div ref={ref} style={{ position: 'relative', width, overflow: 'hidden' }}>
+      <motion.div
+        variants={{
+          hidden: { opacity: 0, y: 75 },
+          visible: { opacity: 1, y: 0 },
+        }}
+        initial="hidden"
+        animate={mainControls}
+        transition={{ duration: 0.6, ease: 'easeOut' }}
+        style={{ width: '100%' }}
+      >
+        {children}
+      </motion.div>
+    </div>
+  )
+}
+


### PR DESCRIPTION
## Summary
- add a generic `Reveal` component for scroll animations
- refactor About, Projects, Blog and Contact sections to use `Reveal`
- remove unused `react-awesome-reveal` dependency

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6853b8eabb888328af857e65bd0142ee